### PR TITLE
feat: Nav JS 완료

### DIFF
--- a/src/assets/icons/nav/search-icon_fixed.svg
+++ b/src/assets/icons/nav/search-icon_fixed.svg
@@ -1,0 +1,9 @@
+<svg width="30" height="30" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M24 24H6V6h18z"/>
+        <path d="M22.5 22.5h-15v-15h15z"/>
+        <g stroke="#333" stroke-linecap="square" stroke-linejoin="round" stroke-width="1.6">
+            <path d="M18.825 13.352c0 1.725-.75 3.225-1.95 4.2-.975.825-2.175 1.275-3.525 1.275a5.457 5.457 0 0 1-5.475-5.475 5.457 5.457 0 0 1 5.475-5.475c3-.075 5.475 2.4 5.475 5.475zM21.375 21.375l-3.75-3.75"/>
+        </g>
+    </g>
+</svg>

--- a/src/css/sections/nav.css
+++ b/src/css/sections/nav.css
@@ -11,12 +11,28 @@
 /* 네비게이션 상단 고정 스타일 */
 #nav.fixed {
     position: fixed;
-    /* fixed로 변경 시 */
     top: 0;
     left: 0;
     width: 100%;
     z-index: 301;
     box-shadow: rgba(0, 0, 0, 0.07) 0px 3px 4px 0px;
+}
+
+#nav.fixed #nav__category {
+    flex: 0 0 120px;
+}
+
+#nav.fixed #nav__items {
+    flex: 0 0 0%;
+}
+
+#nav.fixed #nav__noti {
+    display: none;
+}
+
+/* 고정되었을 때만 표시 */
+#nav.fixed #nav-extra {
+    display: flex;
 }
 
 #nav__list {

--- a/src/css/sections/nav.css
+++ b/src/css/sections/nav.css
@@ -8,6 +8,17 @@
     z-index: 300;
 }
 
+/* 네비게이션 상단 고정 스타일 */
+#nav.fixed {
+    position: fixed;
+    /* fixed로 변경 시 */
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 301;
+    box-shadow: rgba(0, 0, 0, 0.07) 0px 3px 4px 0px;
+}
+
 #nav__list {
     width: 1050px;
     height: 56px;

--- a/src/css/sections/nav.css
+++ b/src/css/sections/nav.css
@@ -23,6 +23,10 @@
     flex: 0 0 120px;
 }
 
+#nav.fixed #nav__center {
+    margin-left: 0;
+}
+
 #nav.fixed #nav__list {
     justify-content: flex-start;
 }
@@ -346,6 +350,10 @@
 }
 
 /* 네비게이션 메뉴 */
+#nav__center {
+    margin-left: auto;
+}
+
 #nav__items {
     display: flex;
     margin-left: 30px;
@@ -377,6 +385,7 @@
 #nav__noti {
     display: flex;
     align-items: center;
+    margin-left: auto;
 }
 
 .delivery-notice {

--- a/src/css/sections/nav.css
+++ b/src/css/sections/nav.css
@@ -35,6 +35,64 @@
     display: flex;
 }
 
+#nav.fixed #header-utility__search {
+    padding-top: 0;
+    margin-top: 0;
+    box-shadow: rgb(247, 247, 247) 0px 0px 0px 1px inset;
+    position: fixed;
+    z-index: 302;
+    top: 10px;
+    width: 242px;
+    height: 36px;
+    border: none;
+    background-color: rgb(247, 247, 247);
+    left: 1050px;
+    margin-left: -405px;
+}
+
+#nav.fixed #search__input {
+    width: 193px;
+    padding-right: 22px;
+    font-weight: 400;
+    font-size: 12px;
+    color: rgb(51, 51, 51);
+    background-color: rgb(247, 247, 247);
+    line-height: 18px;
+}
+
+/* :focus-within을 사용하여 input이 focus 상태일 때 부모의 스타일을 변경 */
+#nav.fixed #header-utility__search:focus-within {
+    background-color: rgb(255, 255, 255);
+}
+
+#nav.fixed #search__input:focus {
+    background-color: rgb(255, 255, 255);
+}
+
+#nav.fixed #search__clear-button {
+    margin-left: -10px;
+    margin-top: 18px;
+    background-size: 12px 12px;
+    margin-top: 11px;
+}
+
+#nav.fixed #search__button {
+    position: relative;
+    margin: 0;
+    margin-top: 3px;
+    height: 30px;
+    top: 0px;
+    width: 40px;
+    background: url(/src/assets/icons/nav/search-icon_fixed.svg) no-repeat;
+}
+
+@media (min-width: 1050px) {
+    #nav.fixed #header-utility__search {
+        left: 50%;
+        margin-left: 120px;
+    }
+}
+
 #nav__list {
     width: 1050px;
     height: 56px;

--- a/src/css/sections/nav.css
+++ b/src/css/sections/nav.css
@@ -16,14 +16,20 @@
     width: 100%;
     z-index: 301;
     box-shadow: rgba(0, 0, 0, 0.07) 0px 3px 4px 0px;
+    display: flex;
 }
 
 #nav.fixed #nav__category {
     flex: 0 0 120px;
 }
 
-#nav.fixed #nav__items {
-    flex: 0 0 0%;
+#nav.fixed #nav__list {
+    justify-content: flex-start;
+}
+
+#nav.fixed #nav__items>* {
+    width: 120px;
+    /* fixed 상태에서 각 항목의 너비를 120px로 줄임 */
 }
 
 #nav.fixed #nav__noti {
@@ -79,17 +85,44 @@
 #nav.fixed #search__button {
     position: relative;
     margin: 0;
-    margin-top: 3px;
     height: 30px;
     top: 0px;
     width: 40px;
     background: url(/src/assets/icons/nav/search-icon_fixed.svg) no-repeat;
 }
 
+#nav.fixed #header-utility__search {
+    display: flex;
+    -webkit-box-align: center;
+    align-items: center;
+    position: fixed;
+    z-index: 302;
+    right: auto;
+    top: 10px;
+    left: 1050px;
+    margin-left: -142px;
+}
+
+#nav.fixed #header-utility__user-menu {
+    display: flex;
+    -webkit-box-align: center;
+    align-items: center;
+    position: fixed;
+    z-index: 302;
+    right: auto;
+    top: 10px;
+    height: 36px;
+}
+
 @media (min-width: 1050px) {
     #nav.fixed #header-utility__search {
         left: 50%;
         margin-left: 120px;
+    }
+
+    #nav.fixed #header-utility__user-menu {
+        left: 50%;
+        margin-left: 383px;
     }
 }
 

--- a/src/js/include/nav.js
+++ b/src/js/include/nav.js
@@ -1,9 +1,17 @@
 includeHtml().then(() => {
     const nav = document.getElementById("nav");
-    if (!nav) {
-        console.error("nav 요소를 찾을 수 없습니다.");
+    const searchBox = document.getElementById("header-utility__search");
+    const userMenu = document.getElementById("header-utility__user-menu");
+    const navExtra = document.getElementById("nav-extra");
+
+    // 검색창과 사용자 메뉴의 원래 부모 저장
+    const headerUtility = searchBox.parentElement;
+
+    if (!nav || !searchBox || !userMenu || !headerUtility || !navExtra) {
+        console.error("필요한 요소를 찾을 수 없습니다.");
         return;
     }
+
 
     // 네비게이션 바의 원래 위치
     const navOffset = nav.offsetTop;
@@ -12,8 +20,16 @@ includeHtml().then(() => {
         // 현재 스크롤 위치가 네비게이션 바의 위치보다 커지면 고정
         if (window.scrollY > navOffset) {
             nav.classList.add("fixed"); // fixed 클래스 추가
+
+            // 검색창과 사용자 메뉴를 nav 안으로 이동
+            navExtra.appendChild(searchBox);
+            navExtra.appendChild(userMenu);
         } else {
             nav.classList.remove("fixed"); // fixed 클래스 제거
+
+            // 원래 위치로 복귀
+            headerUtility.appendChild(searchBox);
+            headerUtility.appendChild(userMenu);
         }
     });
 });

--- a/src/js/include/nav.js
+++ b/src/js/include/nav.js
@@ -1,0 +1,19 @@
+includeHtml().then(() => {
+    const nav = document.getElementById("nav");
+    if (!nav) {
+        console.error("nav 요소를 찾을 수 없습니다.");
+        return;
+    }
+
+    // 네비게이션 바의 원래 위치
+    const navOffset = nav.offsetTop;
+
+    window.addEventListener("scroll", function () {
+        // 현재 스크롤 위치가 네비게이션 바의 위치보다 커지면 고정
+        if (window.scrollY > navOffset) {
+            nav.classList.add("fixed"); // fixed 클래스 추가
+        } else {
+            nav.classList.remove("fixed"); // fixed 클래스 제거
+        }
+    });
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -6,3 +6,4 @@ import './include/header.js';
 import './include/top-banner.js';
 import './include/event.js';
 import './include/modal.js';
+import './include/nav.js';

--- a/src/pages/includes/nav.html
+++ b/src/pages/includes/nav.html
@@ -1,159 +1,164 @@
 <!DOCTYPE html>
 <html lang="ko-KR">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>navgation</title>
-    </head>
 
-    <body>
-        <nav id="nav">
-            <ul id="nav__list">
-                <!-- 카테고리 -->
-                <li id="nav__category">
-                    <button id="category-btn">
-                        <span></span>
-                        <span>카테고리</span>
-                    </button>
-                    <!-- 드롭다운 카테고리 목록 -->
-                    <ul id="category-menu">
-                        <li class="category-item" data-pos="0">
-                            <span class="category-icon"></span>
-                            <a href="#">채소</a>
-                        </li>
-                        <li class="category-item" data-pos="1">
-                            <span class="category-icon"></span>
-                            <a href="#">과일·견과·쌀</a>
-                        </li>
-                        <li class="category-item" data-pos="2">
-                            <span class="category-icon"></span>
-                            <a href="#">수산·해산·건어물</a>
-                        </li>
-                        <li class="category-item" data-pos="3">
-                            <span class="category-icon"></span>
-                            <a href="#">정육·가공육·계란</a>
-                        </li>
-                        <li class="category-item" data-pos="4">
-                            <span class="category-icon"></span>
-                            <a href="#">국·반찬·메인요리</a>
-                        </li>
-                        <li class="category-item" data-pos="5">
-                            <span class="category-icon"></span>
-                            <a href="#">간편식·밀키트·샐러드</a>
-                        </li>
-                        <li class="category-item" data-pos="6">
-                            <span class="category-icon"></span>
-                            <a href="#">면·양념·오일</a>
-                        </li>
-                        <li class="category-item" data-pos="7">
-                            <span class="category-icon"></span>
-                            <a href="#">생수·음료</a>
-                        </li>
-                        <li class="category-item" data-pos="8">
-                            <span class="category-icon"></span>
-                            <a href="#">커피·차</a>
-                        </li>
-                        <li class="category-item" data-pos="9">
-                            <span class="category-icon"></span>
-                            <a href="#">간식·과자·떡</a>
-                        </li>
-                        <li class="category-item" data-pos="10">
-                            <span class="category-icon"></span>
-                            <a href="#">베이커리</a>
-                        </li>
-                        <li class="category-item" data-pos="11">
-                            <span class="category-icon"></span>
-                            <a href="#">유제품</a>
-                        </li>
-                        <li class="category-item" data-pos="12">
-                            <span class="category-icon"></span>
-                            <a href="#">건강식품</a>
-                        </li>
-                        <li class="category-item" data-pos="13">
-                            <span class="category-icon"></span>
-                            <a href="#">와인·위스키·데낄라</a>
-                        </li>
-                        <li class="category-item" data-pos="14">
-                            <span class="category-icon"></span>
-                            <a href="#">전통주</a>
-                        </li>
-                        <li class="category-item" data-pos="15">
-                            <span class="category-icon"></span>
-                            <a href="#">주방용품</a>
-                        </li>
-                        <li class="category-item" data-pos="16">
-                            <span class="category-icon"></span>
-                            <a href="#">생활용품·리빙</a>
-                        </li>
-                        <li class="category-item" data-pos="17">
-                            <span class="category-icon"></span>
-                            <a href="#">가전제품</a>
-                        </li>
-                        <li class="category-item" data-pos="18">
-                            <span class="category-icon"></span>
-                            <a href="#">가구·인테리어</a>
-                        </li>
-                        <li class="category-item" data-pos="19">
-                            <span class="category-icon"></span>
-                            <a href="#">유아동</a>
-                        </li>
-                        <li class="category-item" data-pos="20">
-                            <span class="category-icon"></span>
-                            <a href="#">스포츠·레져·캠핑</a>
-                        </li>
-                        <li class="category-item" data-pos="21">
-                            <span class="category-icon"></span>
-                            <a href="#">반려동물</a>
-                        </li>
-                        <li class="category-item" data-pos="22">
-                            <span class="category-icon"></span>
-                            <a href="#">럭셔리뷰티</a>
-                        </li>
-                        <li class="category-item" data-pos="23">
-                            <span class="category-icon"></span>
-                            <a href="#">스킨케어·메이크업</a>
-                        </li>
-                        <li class="category-item" data-pos="24">
-                            <span class="category-icon"></span>
-                            <a href="#">헤어·바디·구강</a>
-                        </li>
-                        <li class="category-item" data-pos="25">
-                            <span class="category-icon"></span>
-                            <a href="#">패션</a>
-                        </li>
-                        <li class="category-item" data-pos="26">
-                            <span class="category-icon"></span>
-                            <a href="#">컬리상품권</a>
-                        </li>
-                    </ul>
-                </li>
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>navgation</title>
+</head>
 
-                <!-- 내비게이션 메뉴 -->
-                <li>
-                    <ul id="nav__items">
-                        <li class="nav__item">
-                            <a href="#" class="nav__link">신상품</a>
-                        </li>
-                        <li class="nav__item">
-                            <a href="#" class="nav__link">베스트</a>
-                        </li>
-                        <li class="nav__item">
-                            <a href="#" class="nav__link">알뜰쇼핑</a>
-                        </li>
-                        <li class="nav__item">
-                            <a href="#" class="nav__link">특가/혜택</a>
-                        </li>
-                    </ul>
-                </li>
+<body>
+    <nav id="nav">
+        <ul id="nav__list">
+            <!-- 카테고리 -->
+            <li id="nav__category">
+                <button id="category-btn">
+                    <span></span>
+                    <span>카테고리</span>
+                </button>
+                <!-- 드롭다운 카테고리 목록 -->
+                <ul id="category-menu">
+                    <li class="category-item" data-pos="0">
+                        <span class="category-icon"></span>
+                        <a href="#">채소</a>
+                    </li>
+                    <li class="category-item" data-pos="1">
+                        <span class="category-icon"></span>
+                        <a href="#">과일·견과·쌀</a>
+                    </li>
+                    <li class="category-item" data-pos="2">
+                        <span class="category-icon"></span>
+                        <a href="#">수산·해산·건어물</a>
+                    </li>
+                    <li class="category-item" data-pos="3">
+                        <span class="category-icon"></span>
+                        <a href="#">정육·가공육·계란</a>
+                    </li>
+                    <li class="category-item" data-pos="4">
+                        <span class="category-icon"></span>
+                        <a href="#">국·반찬·메인요리</a>
+                    </li>
+                    <li class="category-item" data-pos="5">
+                        <span class="category-icon"></span>
+                        <a href="#">간편식·밀키트·샐러드</a>
+                    </li>
+                    <li class="category-item" data-pos="6">
+                        <span class="category-icon"></span>
+                        <a href="#">면·양념·오일</a>
+                    </li>
+                    <li class="category-item" data-pos="7">
+                        <span class="category-icon"></span>
+                        <a href="#">생수·음료</a>
+                    </li>
+                    <li class="category-item" data-pos="8">
+                        <span class="category-icon"></span>
+                        <a href="#">커피·차</a>
+                    </li>
+                    <li class="category-item" data-pos="9">
+                        <span class="category-icon"></span>
+                        <a href="#">간식·과자·떡</a>
+                    </li>
+                    <li class="category-item" data-pos="10">
+                        <span class="category-icon"></span>
+                        <a href="#">베이커리</a>
+                    </li>
+                    <li class="category-item" data-pos="11">
+                        <span class="category-icon"></span>
+                        <a href="#">유제품</a>
+                    </li>
+                    <li class="category-item" data-pos="12">
+                        <span class="category-icon"></span>
+                        <a href="#">건강식품</a>
+                    </li>
+                    <li class="category-item" data-pos="13">
+                        <span class="category-icon"></span>
+                        <a href="#">와인·위스키·데낄라</a>
+                    </li>
+                    <li class="category-item" data-pos="14">
+                        <span class="category-icon"></span>
+                        <a href="#">전통주</a>
+                    </li>
+                    <li class="category-item" data-pos="15">
+                        <span class="category-icon"></span>
+                        <a href="#">주방용품</a>
+                    </li>
+                    <li class="category-item" data-pos="16">
+                        <span class="category-icon"></span>
+                        <a href="#">생활용품·리빙</a>
+                    </li>
+                    <li class="category-item" data-pos="17">
+                        <span class="category-icon"></span>
+                        <a href="#">가전제품</a>
+                    </li>
+                    <li class="category-item" data-pos="18">
+                        <span class="category-icon"></span>
+                        <a href="#">가구·인테리어</a>
+                    </li>
+                    <li class="category-item" data-pos="19">
+                        <span class="category-icon"></span>
+                        <a href="#">유아동</a>
+                    </li>
+                    <li class="category-item" data-pos="20">
+                        <span class="category-icon"></span>
+                        <a href="#">스포츠·레져·캠핑</a>
+                    </li>
+                    <li class="category-item" data-pos="21">
+                        <span class="category-icon"></span>
+                        <a href="#">반려동물</a>
+                    </li>
+                    <li class="category-item" data-pos="22">
+                        <span class="category-icon"></span>
+                        <a href="#">럭셔리뷰티</a>
+                    </li>
+                    <li class="category-item" data-pos="23">
+                        <span class="category-icon"></span>
+                        <a href="#">스킨케어·메이크업</a>
+                    </li>
+                    <li class="category-item" data-pos="24">
+                        <span class="category-icon"></span>
+                        <a href="#">헤어·바디·구강</a>
+                    </li>
+                    <li class="category-item" data-pos="25">
+                        <span class="category-icon"></span>
+                        <a href="#">패션</a>
+                    </li>
+                    <li class="category-item" data-pos="26">
+                        <span class="category-icon"></span>
+                        <a href="#">컬리상품권</a>
+                    </li>
+                </ul>
+            </li>
 
-                <!-- 배송 안내 -->
-                <li id="nav__noti">
-                    <div class="delivery-notice">
-                        <span>샛별·하루</span>
-                        배송안내
-                    </div>
-                </li>
-            </ul>
-        </nav>
-    </body>
+            <!-- 내비게이션 메뉴 -->
+            <li>
+                <ul id="nav__items">
+                    <li class="nav__item">
+                        <a href="#" class="nav__link">신상품</a>
+                    </li>
+                    <li class="nav__item">
+                        <a href="#" class="nav__link">베스트</a>
+                    </li>
+                    <li class="nav__item">
+                        <a href="#" class="nav__link">알뜰쇼핑</a>
+                    </li>
+                    <li class="nav__item">
+                        <a href="#" class="nav__link">특가/혜택</a>
+                    </li>
+                </ul>
+            </li>
+
+            <!-- 배송 안내 -->
+            <li id="nav__noti">
+                <div class="delivery-notice">
+                    <span>샛별·하루</span>
+                    배송안내
+                </div>
+            </li>
+
+            <!-- 검색창과 사용자 메뉴가 이동될 영역 -->
+            <li id="nav-extra"></li>
+        </ul>
+    </nav>
+</body>
+
 </html>

--- a/src/pages/includes/nav.html
+++ b/src/pages/includes/nav.html
@@ -130,7 +130,7 @@
             </li>
 
             <!-- 내비게이션 메뉴 -->
-            <li>
+            <li id="nav__center">
                 <ul id="nav__items">
                     <li class="nav__item">
                         <a href="#" class="nav__link">신상품</a>


### PR DESCRIPTION
- 스크롤 시 `nav`가 상단에 고정되도록 구현.
- `nav-extra` 영역에 `#header-utility__search`와 `#header-utility__user-menu`가 포함되도록 구현.
- 각각의 요소는 기존 `header`에 있던 상태와는 다른 스타일 적용.

![녹음 2025-03-05 050315](https://github.com/user-attachments/assets/a1553598-ff28-40cf-bc05-542224da06eb)
