### PR TITLE
fix: event.js의 event-page-index 오류 해결

### DIFF
--- a/src/js/include/event.js
+++ b/src/js/include/event.js
@@ -1,5 +1,5 @@
 includeHtml().then(() => {
-    const swiper = new Swiper('.swiper', {
+    const swiper = new Swiper('#event .swiper', {
         slidesPerView: 1, // 한 번에 보여줄 슬라이드 개수
         loop: true, // 슬라이드 무한 반복
         navigation: {
@@ -16,11 +16,6 @@ includeHtml().then(() => {
         autoplay: {
             delay: 3000, // 3초마다 슬라이드 자동 전환
             disableOnInteraction: false,
-        },
-        on: {
-            init: () => {
-                swiper.update();
-            },
         },
     });
 });


### PR DESCRIPTION
- `.swiper` 앞에 `#event`를 정확하게 명시하여 오류 해결
- 페이지 총 개수가 정확하게 표시 됨